### PR TITLE
US22 - Eu, como usuário, quero a opção de pular para o próximo vídeo recomendado, para ter uma experiência contínua de visualização.

### DIFF
--- a/src/app/pages/video-viewer/video-viewer.component.html
+++ b/src/app/pages/video-viewer/video-viewer.component.html
@@ -17,13 +17,19 @@
       </h4>
       <div class="button-container" *ngIf="userId!==''">
         <button class="favorite-button" (click)="toggleFavorite()" [class.favorited]="isFavorite">
-          <img alt="coracao" src="../../../assets/coracao.svg" class="favorite-icon"/> 
+          <img alt="coracao" src="../../../assets/coracao.svg" class="favorite-icon"/>
           <span *ngIf="isFavorite"> Favoritado</span>
           <span *ngIf="!isFavorite"> Favoritar </span>
-        </button> 
+        </button>
         <button class="watch-later-button" (click)="toggleWatchLater()" [ngClass]="{'watch-later-active': isWatchLater}">
           {{ isWatchLater ? 'Remover da lista': 'Assistir Mais Tarde'}}
         </button>
+        <button class="next-video-button" [title]="titleNextVideo" (click)="nextVideo()">
+          Próximo Vídeo
+          <img src="../../../assets/arrow.png" alt="Seta" class="arrow">
+        </button>
+      </div>
+      <div class="button-container" *ngIf="userId==''">
         <button class="next-video-button" [title]="titleNextVideo" (click)="nextVideo()">
           Próximo Vídeo
           <img src="../../../assets/arrow.png" alt="Seta" class="arrow">

--- a/src/app/pages/video-viewer/video-viewer.component.spec.ts
+++ b/src/app/pages/video-viewer/video-viewer.component.spec.ts
@@ -23,6 +23,7 @@ class VideoServiceMock {
     };
     return of(new HttpResponse({ body: mockVideo }));
   }
+
   getRecommendationFromRecord(userId: string) {
     const mockRecommendation = {
       recommend_videos: {
@@ -32,7 +33,6 @@ class VideoServiceMock {
     };
     return of(mockRecommendation);
   }
-
 
   //Procurar próximo vídeo
   findAll() {
@@ -343,12 +343,12 @@ describe('VideoViewerComponent', () => {
   // Histórico
   it('should call addToRecord service method with the correct parameters', () => {
     const addToRecordSpy = spyOn(videoService, 'addToRecord').and.callThrough();
-
+  
     component.userId = '12345';
     component.idVideo = 67890;
 
     component.addRecord();
-
+  
     expect(addToRecordSpy).toHaveBeenCalledWith('12345', '67890');
 
     expect(addToRecordSpy(component.userId, component.idVideo.toString()).subscribe).toBeDefined();
@@ -387,26 +387,53 @@ describe('VideoViewerComponent', () => {
       { id: 1, title: 'Video 1', channels: [{ id: 12, name: "unbtvchannel" }] },
       { id: 2, title: 'Video 2', channels: [{ id: 13, name: "otherchannel" }] }
     ];
-
+  
     component.unbTvChannelId = 12;
     component.unbTvVideos = [];
-
+  
     component.filterVideosByChannel(mockVideos);
-
+  
     expect(component.unbTvVideos.length).toBe(1);
     expect(component.unbTvVideos[0].id).toBe(1);
   });
-
+  
   it('should call checkRecord service method and set recordVideos video-viewer', async () => {
     const expectedResponse = [{ id: 1, title: 'Video 1' }];
     const checkRecordSpy = spyOn(videoService, 'checkRecord').and.returnValue(of(expectedResponse));
-
+  
     component.userId = '12345';
-
+    
     await component.checkRecord();
-
+    
     expect(checkRecordSpy).toHaveBeenCalledWith('12345');
     expect(component.recordVideos).toEqual(expectedResponse);
   });
+
+  it('should check tracking status and set trackingEnabled correctly', fakeAsync(() => {
+    const expectedResponse = { track_enabled: true };
+    const checkTrackingStatusSpy = spyOn(videoService, 'checkTrackingStatus').and.returnValue(of(expectedResponse));
+    
+    component.userId = '1';
+    component.checkTrackingStatus().then(() => {
+      expect(checkTrackingStatusSpy).toHaveBeenCalledWith('1');
+      expect(component.trackingEnabled).toBe(true);
+      console.log('Tracking status:', component.trackingEnabled);
+    });
+    
+    tick(); // Simula a passagem do tempo para a chamada assíncrona
+  }));
+  
+  it('should handle checkTrackingStatus errors gracefully', fakeAsync(() => {
+    const checkTrackingStatusSpy = spyOn(videoService, 'checkTrackingStatus').and.returnValue(throwError('Error'));
+    const consoleErrorSpy = spyOn(console, 'error').and.callThrough(); // Usando callThrough para garantir que a função original ainda seja chamada
+  
+    component.userId = '1';
+    component.checkTrackingStatus().catch(() => {
+      expect(checkTrackingStatusSpy).toHaveBeenCalledWith('1');
+      expect(component.trackingEnabled).toBeTrue();
+    });
+  
+    tick(); // Simula a passagem do tempo para a chamada assíncrona
+  }));
 
 });

--- a/src/app/pages/video-viewer/video-viewer.component.spec.ts
+++ b/src/app/pages/video-viewer/video-viewer.component.spec.ts
@@ -23,6 +23,16 @@ class VideoServiceMock {
     };
     return of(new HttpResponse({ body: mockVideo }));
   }
+  getRecommendationFromRecord(userId: string) {
+    const mockRecommendation = {
+      recommend_videos: {
+        1: 'Mock Video Recommendation 1',
+        2: 'Mock Video Recommendation 2',
+      },
+    };
+    return of(mockRecommendation);
+  }
+
 
   //Procurar próximo vídeo
   findAll() {
@@ -333,12 +343,12 @@ describe('VideoViewerComponent', () => {
   // Histórico
   it('should call addToRecord service method with the correct parameters', () => {
     const addToRecordSpy = spyOn(videoService, 'addToRecord').and.callThrough();
-  
+
     component.userId = '12345';
     component.idVideo = 67890;
 
     component.addRecord();
-  
+
     expect(addToRecordSpy).toHaveBeenCalledWith('12345', '67890');
 
     expect(addToRecordSpy(component.userId, component.idVideo.toString()).subscribe).toBeDefined();
@@ -377,35 +387,26 @@ describe('VideoViewerComponent', () => {
       { id: 1, title: 'Video 1', channels: [{ id: 12, name: "unbtvchannel" }] },
       { id: 2, title: 'Video 2', channels: [{ id: 13, name: "otherchannel" }] }
     ];
-  
+
     component.unbTvChannelId = 12;
     component.unbTvVideos = [];
-  
+
     component.filterVideosByChannel(mockVideos);
-  
+
     expect(component.unbTvVideos.length).toBe(1);
     expect(component.unbTvVideos[0].id).toBe(1);
   });
-  
+
   it('should call checkRecord service method and set recordVideos video-viewer', async () => {
     const expectedResponse = [{ id: 1, title: 'Video 1' }];
     const checkRecordSpy = spyOn(videoService, 'checkRecord').and.returnValue(of(expectedResponse));
-  
+
     component.userId = '12345';
-    
+
     await component.checkRecord();
-    
+
     expect(checkRecordSpy).toHaveBeenCalledWith('12345');
     expect(component.recordVideos).toEqual(expectedResponse);
   });
 
-  /*it('should check tracking status and set trackingEnabled correctly', fakeAsync(() => {
-    const mySpy = spyOn(videoService, 'checkTrackingStatus').and.returnValue(of({ track_enabled: true }));
-    component.userId = '1';
-    tick(); // Simulate passage of time for the async call
-    component.checkTrackingStatus().then(() => {
-      expect(mySpy).toHaveBeenCalledWith('1');
-      expect(component.trackingEnabled).toBe(true);
-    });
-  }));*/
 });

--- a/src/app/pages/video-viewer/video-viewer.component.ts
+++ b/src/app/pages/video-viewer/video-viewer.component.ts
@@ -42,6 +42,7 @@ export class VideoViewerComponent implements OnInit {
   showTitleNextVideo: boolean = false;
   recommendedVideos: any = [];
   recommendedVideo: any;
+  trackingEnabled: boolean = true;
 
   expandDescription() {
     this.showDescription = !this.showDescription;
@@ -102,6 +103,11 @@ export class VideoViewerComponent implements OnInit {
         }
       });
     });
+  }
+  async checkTrackingStatus(): Promise<void> {
+    const status = await this.videoService.checkTrackingStatus(this.userId).toPromise();
+    this.trackingEnabled = status.track_enabled;
+    console.log('Tracking status:', this.trackingEnabled);
   }
 
   //Função responsável por trazer todos os vídeos já assistidos pelo usuário
@@ -178,7 +184,7 @@ export class VideoViewerComponent implements OnInit {
         window.location.reload();
       });
     }
-  }  
+  }
 
   setUserIdFromToken(token: string) {
     const decodedToken: any = jwt_decode(token);

--- a/src/app/pages/video-viewer/video-viewer.component.ts
+++ b/src/app/pages/video-viewer/video-viewer.component.ts
@@ -123,7 +123,6 @@ export class VideoViewerComponent implements OnInit {
   }
 
   filterRecommendVideo(): void {
-    console.log("teste: ", Object.values(this.recommendedVideos.recommend_videos));
     this.recommendedVideo = Object.values(this.recommendedVideos.recommend_videos)[0];
   }
 
@@ -135,7 +134,6 @@ export class VideoViewerComponent implements OnInit {
         this.videoService.videosCatalog(this.unbTvVideos, this.catalog)
 
         if(this.authService.isAuthenticated() && this.trackingEnabled){
-          console.log("dentro do if")
           //Loop para encontrar a categoria do vídeo atual
           this.unbTvVideos.forEach((video) => {
             if(video.id == this.idVideo){
@@ -147,19 +145,12 @@ export class VideoViewerComponent implements OnInit {
           this.program = this.videoService.findProgramName(this.catalog, this.categoryVideo, this.idVideo);
 
           this.videosByCategory = this.videoService.filterVideosByCategory(this.unbTvVideos, this.categoryVideo);
-          console.log("vídeos da categoria do atual: ", this.videosByCategory)
           this.filterVideosByRecord();
-          console.log("videos assistidos: ", this.filteredVideos)
           this.filterRecommendVideo();
           this.idNextVideo = this.videoService.recommendVideo(this.videosByCategory, this.catalog, this.categoryVideo, this.filteredVideos, this.program, this.recommendedVideo);
         }else{
-          console.log("dentro do else")
-          console.log("id do video atual: ", this.idVideo)
-          console.log("array de videos unbtv: ", this.unbTvVideos)
           for(const i in this.unbTvVideos){
             if(this.unbTvVideos[i].id == this.idVideo){
-              console.log("video encontrado: ", this.unbTvVideos[i])
-              console.log("posição do vídeo atual no array: ", i)
               if(Number(i) == (this.unbTvVideos.length - 1)){
                 this.idNextVideo = Number(this.unbTvVideos[0].id);
               }else{
@@ -168,27 +159,20 @@ export class VideoViewerComponent implements OnInit {
               break;
             }
           }
-          console.log("próximo video: ", this.unbTvVideos[this.idNextVideo])
 
         }
         //Se o id for diferente de -1, o usuário ainda não viu todos os vídeos da categoria atual
         if(this.idNextVideo != -1){
-          console.log("entrou no if do next video: ", this.idNextVideo)
           //Loop para encontrar o título do próximo vídeo
           this.unbTvVideos.forEach((video) => {
-            //console.log("id do video: ", video.id)
             if(video.id == this.idNextVideo){
-              console.log("entrou aqui")
               this.titleNextVideo = video.title;
               return;
             }
           })
         }else{
-          console.log("entrou no else do next video")
           this.titleNextVideo = "Não há vídeo para ser recomendado"
         }
-        console.log("id do próximo vídeo: ", this.idNextVideo)
-        console.log("título do próximo vídeo: ", this.titleNextVideo)
       },
       error: (error) => {
         console.log(error);

--- a/src/app/services/video.service.spec.ts
+++ b/src/app/services/video.service.spec.ts
@@ -1321,5 +1321,28 @@ describe('toggleTracking', () => {
       expect(nextVideoId).toBe(123456); // Invalid category and program
     });
   });  
+
+  describe('getRecommendationFromRecord', () => {
+    it('should get the recommendation from record for a user', () => {
+      const mockUserId = 'user123';
+      const mockResponse = {
+        recommend_videos: {
+          1: 'Mock Video Recommendation 1',
+          2: 'Mock Video Recommendation 2',
+        },
+      };
+  
+      service.getRecommendationFromRecord(mockUserId).subscribe((response) => {
+        expect(response).toEqual(mockResponse);
+      });
+  
+      const req = httpMock.expectOne(
+        `${environment.videoAPIURL}/recommendation/get_recommendation_record/?user_id=${mockUserId}`
+      );
+      expect(req.request.method).toBe('GET');
+  
+      req.flush(mockResponse);
+    });
+  });
   
 });

--- a/src/app/services/video.service.spec.ts
+++ b/src/app/services/video.service.spec.ts
@@ -1266,7 +1266,8 @@ describe('toggleTracking', () => {
         catalog,
         'Jornalismo',
         watchedVideos,
-        'falaJovem'
+        'falaJovem',
+        123456
       );
   
       expect(nextVideoId).toBe(2); // Informe UnB should be recommended next
@@ -1280,13 +1281,14 @@ describe('toggleTracking', () => {
         catalog,
         'Arte e Cultura',
         watchedVideos,
-        'esbocos'
+        'esbocos',
+        123456
       );
   
       expect(nextVideoId).toBe(3); // Esboços: Artista should be recommended
     });
   
-    it('should return -1 if all videos in the category are watched', () => {
+    it('should return the recommended video id if all videos in the category are watched', () => {
       watchedVideos = [
         { id: 1, title: 'Fala, jovem', catalog: 'Jornalismo' } as IVideo,
         { id: 2, title: 'Informe UnB', catalog: 'Jornalismo' } as IVideo,
@@ -1299,22 +1301,24 @@ describe('toggleTracking', () => {
         catalog,
         'Jornalismo',
         watchedVideos,
-        'falaJovem'
+        'falaJovem',
+        123456
       );
     
-      expect(nextVideoId).toBe(-1); // No video left to recommend
+      expect(nextVideoId).toBe(123456); // No video left to recommend
     });
   
-    it('should return -1 if the program or category does not exist', () => {
+    it('should return the recommended video id if the program or category does not exist', () => {
       const nextVideoId = videoService.recommendVideo(
         videos,
         catalog,
         'Nonexistent Category',
         watchedVideos,
-        'nonexistentProgram'
+        'unbtv',
+        123456
       );
   
-      expect(nextVideoId).toBe(-1); // Invalid category and program
+      expect(nextVideoId).toBe(123456); // Invalid category and program
     });
   });  
   

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -12,11 +12,9 @@ import { IEduplayVideosByInstitution } from 'src/shared/model/eduplay-by-institu
 import { environment } from '../environment/environment';
 import { Catalog } from 'src/shared/model/catalog.model';
 
-
 type VideoResponseType = HttpResponse<IVideo>;
 type EduplayByInstitutionResponseType =
   HttpResponse<IEduplayVideosByInstitution>;
-
 
 @Injectable({
   providedIn: 'root',
@@ -31,9 +29,7 @@ export class VideoService {
   private selectedCatalogProgram = new BehaviorSubject<IVideo[]>([]);
   //catalog: Catalog = new Catalog();
 
-
   constructor(private http: HttpClient) { }
-
 
   findAll(): Observable<EduplayByInstitutionResponseType> {
     let headers = new HttpHeaders({ clientkey: this.eduplayClientKey });
@@ -43,10 +39,8 @@ export class VideoService {
     );
   }
 
-
   findVideoById(idVideo: number): Observable<VideoResponseType> {
     let headers = new HttpHeaders({ clientkey: this.eduplayClientKey });
-
 
     return this.http.get<IVideo>(`${this.resourceUrl}/${idVideo}`, {
       headers: headers,
@@ -54,16 +48,13 @@ export class VideoService {
     });
   }
 
-
   setVideosCatalog(videos: IVideo[]) {
     this.selectedCatalogProgram.next(videos);
   }
 
-
   getVideosCatalog(): Observable<IVideo[]> {
     return this.selectedCatalogProgram.asObservable();
   }
-
 
   //atribui categoria aos videos
   videosCatalog(videos: IVideo[], catalog: Catalog): void {
@@ -224,10 +215,8 @@ export class VideoService {
       },
     ];
 
-
     videos.forEach((video) => {
       const keywordsTitle = video?.title?.toLowerCase() ?? '';
-
 
       if (keywordsTitle) {
         const category = keywordsCategories.find((config) =>
@@ -375,7 +364,6 @@ export class VideoService {
     return this.http.post(`${this.videoServiceApiURL}/watch-later/`, { video_id: videoId, user_id: userId });
   }
 
-
   removeFromWatchLater(videoId: string, userId: string): Observable<any> {
     return this.http.delete(`${this.videoServiceApiURL}/watch-later/${videoId}`, {
       params: { user_id: userId }
@@ -388,13 +376,11 @@ export class VideoService {
     });
   }
 
-
   getWatchLaterVideos(userId: string): Observable<any> {
     return this.http.get<any>(`${this.videoServiceApiURL}/watch-later/`, {
       params: { user_id: userId }
     });
   }
-
 
   // Favoritar
   addToFavorite(videoId: string, userId: string): Observable<any> {
@@ -402,62 +388,57 @@ export class VideoService {
     return this.http.post(`${this.videoServiceApiURL}/favorite/`, { video_id: videoId, user_id: userId });
   }
 
-
   removeFromFavorite(videoId: string, userId: string): Observable<any> {
     return this.http.delete(`${this.videoServiceApiURL}/favorite/${videoId}`, {
       params: { user_id: userId }
     });
   }
  
-
-
   checkFavorite(videoId: string, userId: string): Observable<any> {
     return this.http.get<any>(`${this.videoServiceApiURL}/favorite/status/${videoId}`, {
       params: { user_id: userId }
     });
   }
 
-
   getFavoriteVideos(userId: string): Observable<any> {
     return this.http.get<any>(`${this.videoServiceApiURL}/favorite/`, {
       params: { user_id: userId }
     });
   }
-   // Historico
+  
+  // Historico
   checkRecord(userId: string): Observable<any> {
     return this.http.get<any>(`${this.videoServiceApiURL}/record/get_record/`, {
       params: { user_id: userId }
     });
   }
 
-
- addToRecord(userId: string, videoId: string): Observable<any> {
+  addToRecord(userId: string, videoId: string): Observable<any> {
     const currentDateTime: string = new Date().toLocaleString();
     return this.http.post(`${this.videoServiceApiURL}/record/`, { user_id: userId.toString(), videos: { [videoId]: currentDateTime}});
   }
 
-
   toggleTracking(userId: string, track: boolean): Observable<any> {
-  return this.http.post(`${this.videoServiceApiURL}/record/toggle_tracking/`, null, {
-    params: { user_id: userId, track: track.toString() }
-  });
-}
+    return this.http.post(`${this.videoServiceApiURL}/record/toggle_tracking/`, null, {
+      params: { user_id: userId, track: track.toString() }
+    });
+  }
 
+  getRecordSorted(userId: string, ascending: boolean): Observable<any> {
+    return this.http.get<any>(`${this.videoServiceApiURL}/record/get_record_sorted/`, {
+      params: { user_id: userId, ascending: ascending.toString() }
+    });
+  }
 
-getRecordSorted(userId: string, ascending: boolean): Observable<any> {
-  return this.http.get<any>(`${this.videoServiceApiURL}/record/get_record_sorted/`, {
-    params: { user_id: userId, ascending: ascending.toString() }
-  });
-}
+  checkTrackingStatus(userId: string): Observable<any> {
+    return this.http.get<any>(`${this.videoServiceApiURL}/record/get_tracking_status/`, {
+      params: { user_id: userId }
+    });
+  }
 
-
-checkTrackingStatus(userId: string): Observable<any> {
-  return this.http.get<any>(`${this.videoServiceApiURL}/record/get_tracking_status/`, {
-    params: { user_id: userId }
-  });
-}
-
-
-
-
+  getRecommendationFromRecord(userId: string): Observable<any> {
+    return this.http.get<any>(`${this.videoServiceApiURL}/recommendation/get_recommendation_record/`, {
+      params: { user_id: userId }
+    });
+  }
 }

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -318,7 +318,6 @@ export class VideoService {
           if (section) {
             for (const video of section) {
               if (video.id == currentVideoId) {
-                //console.log(`o programa é ${programName}`);
                 return programName;
               }
             }
@@ -326,7 +325,6 @@ export class VideoService {
         }
       }
     }
-    //console.log("o programa é unb tv");
     return "unbtv";
   }
 
@@ -342,7 +340,6 @@ export class VideoService {
 
     if(program != 'unbtv'){
       const currentProgram = programMap[program];
-      //console.log("currentProgram: ", currentProgram)
 
       if (currentProgram) {
         const videoNaoAssistido = currentProgram.find((video: IVideo) => !watchedVideos.some((v: IVideo) => v.id === video.id));
@@ -367,7 +364,6 @@ export class VideoService {
 
   //Assistir Mais Tarde
   addToWatchLater(videoId: string, userId: string): Observable<any> {
-    //console.log(videoId,userId)
     return this.http.post(`${this.videoServiceApiURL}/watch-later/`, { video_id: videoId, user_id: userId });
   }
 
@@ -391,7 +387,6 @@ export class VideoService {
 
   // Favoritar
   addToFavorite(videoId: string, userId: string): Observable<any> {
-    //console.log('Adding to favorite:', videoId, userId)
     return this.http.post(`${this.videoServiceApiURL}/favorite/`, { video_id: videoId, user_id: userId });
   }
 

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -331,30 +331,37 @@ export class VideoService {
   }
 
   //recomenda os videos do mesmo programa e depois videos da mesma categoria
-  recommendVideo(videos: IVideo[], catalog: Catalog, currentVideoCategory: string, watchedVideos: IVideo[], program: string): any {
+  recommendVideo(videos: IVideo[], catalog: Catalog, currentVideoCategory: string, watchedVideos: IVideo[], program: string, recommendedVideo: any): any {
     const { catalogMap } = this.getCatalogAndProgramMaps(catalog);
 
     const programMap = catalogMap[currentVideoCategory];
 
-    if (!programMap) {
+    /*if (!programMap) {
       return -1;
-    }
+    }*/
 
-    const currentProgram = programMap[program];
-    //console.log("currentProgram: ", currentProgram)
+    if(program != 'unbtv'){
+      const currentProgram = programMap[program];
+      //console.log("currentProgram: ", currentProgram)
 
-    if (currentProgram) {
-      const videoNaoAssistido = currentProgram.find((video: IVideo) => !watchedVideos.some((v: IVideo) => v.id === video.id));
-      if (videoNaoAssistido) {
-        return videoNaoAssistido.id;
+      if (currentProgram) {
+        const videoNaoAssistido = currentProgram.find((video: IVideo) => !watchedVideos.some((v: IVideo) => v.id === video.id));
+        if (videoNaoAssistido) {
+          return videoNaoAssistido.id;
+        }
+      }
+
+      // Se já assistiu todos os vídeos do programa atual, procurar em outros programas da mesma categoria
+      const videoNaoAssistidoDeOutraCategoria = videos.find((video: IVideo) => !watchedVideos.some((v: IVideo) => v.id === video.id));
+      if (videoNaoAssistidoDeOutraCategoria) {
+        return videoNaoAssistidoDeOutraCategoria.id;
       }
     }
 
-    // Se já assistiu todos os vídeos do programa atual, procurar em outros programas da mesma categoria
-    const videoNaoAssistidoDeOutraCategoria = videos.find((video: IVideo) => !watchedVideos.some((v: IVideo) => v.id === video.id));
-    if (videoNaoAssistidoDeOutraCategoria) {
-      return videoNaoAssistidoDeOutraCategoria.id;
+    if(recommendedVideo){
+      return recommendedVideo;
     }
+
     return -1;
   }
 


### PR DESCRIPTION
# US22 - Adição de Recomendação Personalizada ao Botão de Próximo Vídeo.

## 1. Descrição breve da issue

Adição da feature de recomendação de vídeos personalizada para cada usuário ao botão de próximo vídeo. A ordem de prioridade para encontrar o próximo vídeo é (para usuários logados e com o rastreamento de histórico ativado):

1- Mesmo programa
2- Mesma categoria
3- Vídeo mais recomendado

Também foi corrigido o funcionamento do botão de próximo vídeo para usuários não logados e usuários com o rastreamento de histórico desativado. Para esses casos, o funcionamento do botão não é personalizado e funciona de maneira linear (avança para o próximo vídeo do array de vídeos da UnB-TV).

## 2. Issue Relacionada

https://github.com/fga-eps-mds/2024.1-UnB-TV-DOC/issues/65

## 3. Como Isso Foi Testado?

Testes unitários e de usabilidade seguindo os critérios de aceitação.

## Critérios de aceitação para o PR

- [x] Testes criados.
- [x] Testes passando.
- [x] Build passando.